### PR TITLE
Update to latest Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 此Web App是以重力波資料分析作為範例，用來教學及推廣公民科學，由[蘇羿豪](https://astrobackhacker.tw/)基於[Streamlit](https://streamlit.io/)開發，[程式碼](https://github.com/YihaoSu/GravitationalWaveDataAnalysisStreamlitUI)以MIT授權條款開源，並將開發過程紀錄在2022 iThome鐵人賽的系列文章「[跟著黑蛋用Streamlit速成天文資料分析Web App](https://ithelp.ithome.com.tw/users/20103436/ironman/5820)」中。
 
+本專案已更新至最新版的 Streamlit，相依套件請依照 `requirements.txt` 安裝。
+
 點擊上方的「Open in Streamlit」圖示，即可瀏覽此app。
 
 ## 在自己的電腦上運行此app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.13.0
+streamlit>=1.45.1
 streamlit-aggrid==0.3.4.post3
 gwpy==3.0.7
 plotly==5.10.0

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -4,7 +4,7 @@ from gwpy.time import from_gps
 from gwpy.timeseries import TimeSeries
 
 
-@st.experimental_memo(ttl=86400, show_spinner=False)
+@st.cache_data(ttl=86400, show_spinner=False)
 def get_gw_event_table_by_gwpy():
     gw_event_table = EventTable.fetch_open_data('GWTC').to_pandas()
     gw_event_table = gw_event_table[
@@ -42,7 +42,7 @@ def convert_gps_to_utc(gw_event_table):
     return gw_event_table
 
 
-@st.experimental_memo(ttl=3600, show_spinner=False)
+@st.cache_data(ttl=3600, show_spinner=False)
 def get_gw_event_data(detector, gw_event_gps_time):
     gw_event_data = TimeSeries.fetch_open_data(
         detector,


### PR DESCRIPTION
## Summary
- upgrade to the latest Streamlit in requirements
- use `st.cache_data` instead of deprecated caching API
- document new Streamlit requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `streamlit --version`


------
https://chatgpt.com/codex/tasks/task_e_683f77d2e49c8323a006de92f7187c0c