### PR TITLE
Fix numpy bool8 error in Plotly

### DIFF
--- a/pages/03_Gravitational_wave_statistical_charts.py
+++ b/pages/03_Gravitational_wave_statistical_charts.py
@@ -1,3 +1,8 @@
+import numpy as np
+
+if not hasattr(np, "bool8"):
+    np.bool8 = np.bool_
+
 import streamlit as st
 import plotly.express as px
 


### PR DESCRIPTION
## Summary
- patch statistical charts page to restore deprecated `np.bool8`

## Testing
- `python - <<'EOF'
import numpy as np
import plotly.express as px
print('plotly loaded, bool8 attr', hasattr(np, 'bool8'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683f7a7fbabc8323a0df44b10e653d77