### PR TITLE
Fix numpy product error

### DIFF
--- a/pages/03_Gravitational_wave_statistical_charts.py
+++ b/pages/03_Gravitational_wave_statistical_charts.py
@@ -1,7 +1,10 @@
 import numpy as np
 
+# Compatibility patches for deprecated numpy attributes used by dependencies
 if not hasattr(np, "bool8"):
     np.bool8 = np.bool_
+if not hasattr(np, "product"):
+    np.product = np.prod
 
 import streamlit as st
 import plotly.express as px


### PR DESCRIPTION
## Summary
- patch numpy compatibility for dependencies expecting `numpy.product`

## Testing
- `python -m py_compile Home.py pages/*.py utilities/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7e6f0ac48323a610431a78792aa3