### PR TITLE
Fix dependency versions in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.45.1
-streamlit-aggrid>=1.1.5.post1
+streamlit-aggrid==1.0.5
 gwpy>=3.0.12
 plotly>=6.1.2
-altair>=5.5.0
+altair==4.2.2


### PR DESCRIPTION
## Summary
- align `streamlit-aggrid` with latest available release
- use compatible `altair` version

## Testing
- `pip install -r requirements.txt --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_683f83a1f3b883238b906c381cf4f0f3