### PR TITLE
Fix altair dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ streamlit>=1.45.1
 streamlit-aggrid==1.0.5
 gwpy>=3.0.12
 plotly>=6.1.2
-altair==5.5.0
+altair<5


### PR DESCRIPTION
## Summary
- relax version pin for `altair` so it stays below 5

## Testing
- `python3 -m pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_683f913942b08323ae41d5de6c1f8e34