### PR TITLE
Keep astropy requirement only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ streamlit-aggrid==1.0.5
 gwpy>=3.0.12
 plotly>=6.1.2
 altair<5
+astropy>=7.1.0


### PR DESCRIPTION
## Summary
- revert accidental patch_numpy imports
- keep the astropy dependency update

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f9e57465c83238179904c839c05a5